### PR TITLE
Week 3 Session 1 - Revised language model and N-gram introduction

### DIFF
--- a/book/ko/week03/session1.md
+++ b/book/ko/week03/session1.md
@@ -201,18 +201,19 @@ N-gram 모델을 더 잘 이해하기 위해 바이그램 전이를 시각화해
 !apt-get install -y fonts-nanum
 !sudo fc-cache -fv
 !rm ~/.cache/matplotlib -rf
-```
-
-
-```python
 # 폰트 캐시 갱신
 !fc-cache -fv
+```
 
+```python
 # matplotlib에 나눔고딕 폰트 강제로 설정
 import matplotlib.pyplot as plt
 import matplotlib.font_manager as fm
 
 # 나눔고딕 폰트 경로를 가져와서 직접 설정
+# NanumGothic is a widely used Korean font that ensures proper display of Hangul characters.
+# It's freely available and provides good readability for Korean text in data visualizations.
+# This font is chosen to ensure that Korean characters are rendered correctly and legibly.
 font_path = '/usr/share/fonts/truetype/nanum/NanumGothic.ttf'
 fontprop = fm.FontProperties(fname=font_path)
 plt.rcParams['font.family'] = fontprop.get_name()
@@ -233,7 +234,7 @@ def visualize_bigrams(bigram_probs, top_n=5):
 
     # 노드에 한글 폰트 적용
     nx.draw(G, pos, with_labels=True, node_color='lightblue',
-            node_size=3000, font_size=10, font_weight='bold', 
+            node_size=3000, font_size=10, font_weight='bold',
             font_family=fontprop.get_name())  # 노드 레이블에 한글 폰트 적용
 
     edge_labels = {(w1, w2): f"{prob:.2f}" for (w1, w2), prob in bigram_probs.items()}

--- a/book/ko/week03/session1.md
+++ b/book/ko/week03/session1.md
@@ -70,6 +70,7 @@ def calculate_bigram_prob(corpus):
     bigram_counts = defaultdict(int)
     unigram_counts = defaultdict(int)
 
+    #마지막 단어는 바이그램에서 제외되므로, 별도로 마지막 단어의 유니그램 빈도를 추가
     for i in range(len(tokens) - 1):
         bigram = (tokens[i], tokens[i+1])
         bigram_counts[bigram] += 1
@@ -196,7 +197,29 @@ print(f"퍼플렉시티: {perplexity:.2f}")
 N-gram 모델을 더 잘 이해하기 위해 바이그램 전이를 시각화해 보겠습니다:
 
 ```python
+# 나눔고딕 폰트 설치
+!apt-get install -y fonts-nanum
+!sudo fc-cache -fv
+!rm ~/.cache/matplotlib -rf
+```
+
+
+```python
+# 폰트 캐시 갱신
+!fc-cache -fv
+
+# matplotlib에 나눔고딕 폰트 강제로 설정
 import matplotlib.pyplot as plt
+import matplotlib.font_manager as fm
+
+# 나눔고딕 폰트 경로를 가져와서 직접 설정
+font_path = '/usr/share/fonts/truetype/nanum/NanumGothic.ttf'
+fontprop = fm.FontProperties(fname=font_path)
+plt.rcParams['font.family'] = fontprop.get_name()
+
+# 폰트 적용 확인
+print(fm.FontProperties(fname=font_path).get_name())
+
 import networkx as nx
 
 def visualize_bigrams(bigram_probs, top_n=5):
@@ -207,8 +230,11 @@ def visualize_bigrams(bigram_probs, top_n=5):
 
     pos = nx.spring_layout(G)
     plt.figure(figsize=(12, 8))
+
+    # 노드에 한글 폰트 적용
     nx.draw(G, pos, with_labels=True, node_color='lightblue',
-            node_size=3000, font_size=10, font_weight='bold')
+            node_size=3000, font_size=10, font_weight='bold', 
+            font_family=fontprop.get_name())  # 노드 레이블에 한글 폰트 적용
 
     edge_labels = {(w1, w2): f"{prob:.2f}" for (w1, w2), prob in bigram_probs.items()}
     nx.draw_networkx_edge_labels(G, pos, edge_labels=edge_labels, font_size=8)
@@ -218,7 +244,9 @@ def visualize_bigrams(bigram_probs, top_n=5):
     plt.tight_layout()
     plt.show()
 
+# 예시 실행
 visualize_bigrams(bigram_probs)
+
 ```
 
 이 시각화는 우리의 바이그램 모델에서 단어 간 전이를 보여주며, 간선의 가중치는 전이 확률을 나타냅니다.


### PR DESCRIPTION
### **User description**
1. Google Colab에서 한글 깨짐 문제 해결: 한글이 깨져서 나오지 않는 문제를 해결하기 위해 NanumGothic 폰트 설치 및 적용 방법을 요청. !apt-get install -y fonts-nanum 명령어로 폰트를 설치하고, Matplotlib에 나눔고딕 폰트를 설정하는 방법 제시.

2.폰트 캐시 갱신 오류 해결:
matplotlib.font_manager._rebuild()가 더 이상 사용되지 않아 발생한 폰트 캐시 갱신 오류 해결 요청. _rebuild() 대신 !fc-cache -fv 명령어를 사용해 폰트 캐시 갱신을 제안하고 해결.

3. 폰트가 제대로 적용되지 않는 문제 해결: NanumGothic 폰트가 설치되었지만 Matplotlib에서 인식되지 않는 문제 해결을 위해, 폰트 강제 설정 방법을 제시. matplotlib에서 폰트 경로를 직접 설정하고, plt.rcParams['font.family']로 폰트를 명시적으로 적용하도록 제안.

4. 그래프 제목은 한글로 나오지만 노드 레이블이 한글로 표시되지 않는 문제 해결: 그래프의 제목은 한글로 표시되지만, 노드 레이블이 한글로 표시되지 않는 문제를 해결하기 위해, 노드 레이블에 한글 폰트 적용을 요청. nx.draw() 함수에서 font_family 파라미터를 추가하여 노드 레이블에도 나눔고딕 폰트를 적용하는 방법을 제안.

5. 2.3 N-gram 확률 계산 코드 설명 추가


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Added steps to install and configure NanumGothic font in Google Colab to address Korean text rendering issues.
- Updated the code to refresh the font cache using `!fc-cache -fv` and set the font properties in Matplotlib for consistent font application.
- Enhanced the visualization of bigram transitions by applying Korean fonts to node labels in network graphs.
- Included comments and an example execution to demonstrate the visualization of bigram probabilities.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>session1.md</strong><dd><code>Enhance Korean font support and visualization in N-gram tutorial</code></dd></summary>
<hr>

book/ko/week03/session1.md

<li>Added instructions to install and configure NanumGothic font in Google <br>Colab.<br> <li> Updated code to refresh font cache and set font properties in <br>Matplotlib.<br> <li> Applied Korean font to node labels in network graphs.<br> <li> Added comments and example execution for visualization function.<br>


</details>


  </td>
  <td><a href="https://github.com/entelecheia/intronlp-2024/pull/90/files#diff-bff94e49c3e2ceed5a7e24678b561eb320c8e96b677fc40a6715b4417fbc793b">+29/-1</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix various issues related to Korean text display in Google Colab by installing and configuring the NanumGothic font. Update the documentation to include an explanation of N-gram probability calculation. Ensure that both graph titles and node labels display correctly in Korean by applying the appropriate font settings.

Bug Fixes:
- Resolve Korean text display issues in Google Colab by installing and applying the NanumGothic font.
- Fix font cache update error by replacing the deprecated matplotlib.font_manager._rebuild() with the !fc-cache -fv command.
- Ensure proper application of the NanumGothic font in Matplotlib by explicitly setting the font path and using plt.rcParams['font.family'].
- Address issue where node labels in graphs were not displaying in Korean by applying the NanumGothic font to node labels using the font_family parameter in nx.draw().

Documentation:
- Add explanation for N-gram probability calculation code in the documentation.

<!-- Generated by sourcery-ai[bot]: end summary -->